### PR TITLE
Create dockerfile environment variable for version, plus update to most recent version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu:latest
 
+ENV VERSION=1.12.0.28
+
 # Install dependencies, download and extract the bedrock server
 RUN apt-get update && \
     apt-get install -y unzip curl libcurl4 libssl1.0.0 && \
-    curl https://minecraft.azureedge.net/bin-linux/bedrock-server-1.11.2.1.zip --output bedrock-server.zip && \
+    curl https://minecraft.azureedge.net/bin-linux/bedrock-server-${VERSION}.zip --output bedrock-server.zip && \
     unzip bedrock-server.zip -d bedrock-server && \
     rm bedrock-server.zip
 


### PR DESCRIPTION
Hi,
  I believe this change will allow someone to pass a runtime environment variable in for the version, meaning you can update the version without waiting on repo changes.

I also updated to the release made today.

Thanks!