### PR TITLE
Allow auto-version based on build argument of 'latest'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
+ARG BDS_Version=1.12.0.28
 FROM ubuntu:latest
-
-ENV VERSION=1.12.0.28
+ENV VERSION=${BDS_Version}
 
 # Install dependencies, download and extract the bedrock server
+
+RUN if [ "$VERSION" = "latest" ] ; then LATEST_VERSION=$(curl -v --silent  https://www.minecraft.net/en-us/download/server/bedrock/ 2>&1 |grep -o 'https://minecraft.azureedge.net/bin-linux/[^"]*' | sed 's#.*/bedrock-server-##' | sed 's/.zip//') && export VERSION=$LATEST_VERSION && echo "Setting VERSION to $LATEST_VERSION" ; else echo "Using VERSION of $VERSION"; fi
 RUN apt-get update && \
     apt-get install -y unzip curl libcurl4 libssl1.0.0 && \
     curl https://minecraft.azureedge.net/bin-linux/bedrock-server-${VERSION}.zip --output bedrock-server.zip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ ENV VERSION=$BDS_Version
 
 # Install dependencies, download and extract the bedrock server
 
+RUN apt-get update && \
+    apt-get install -y unzip curl libcurl4 libssl1.0.0
+    
 RUN if [ "$VERSION" = "latest" ] ; then \
         LATEST_VERSION=$( \
             curl -v --silent  https://www.minecraft.net/en-us/download/server/bedrock/ 2>&1 | \
@@ -14,10 +17,7 @@ RUN if [ "$VERSION" = "latest" ] ; then \
         echo "Setting VERSION to $LATEST_VERSION" ; \
     else echo "Using VERSION of $VERSION"; \
     fi
-    
-RUN apt-get update && \
-    apt-get install -y unzip curl libcurl4 libssl1.0.0 && \
-    curl https://minecraft.azureedge.net/bin-linux/bedrock-server-${VERSION}.zip --output bedrock-server.zip && \
+RUN curl https://minecraft.azureedge.net/bin-linux/bedrock-server-${VERSION}.zip --output bedrock-server.zip && \
     unzip bedrock-server.zip -d bedrock-server && \
     rm bedrock-server.zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,16 @@ ENV VERSION=$BDS_Version
 
 # Install dependencies, download and extract the bedrock server
 
-RUN if [ "$VERSION" = "latest" ] ; then LATEST_VERSION=$(curl -v --silent  https://www.minecraft.net/en-us/download/server/bedrock/ 2>&1 |grep -o 'https://minecraft.azureedge.net/bin-linux/[^"]*' | sed 's#.*/bedrock-server-##' | sed 's/.zip//') && export VERSION=$LATEST_VERSION && echo "Setting VERSION to $LATEST_VERSION" ; else echo "Using VERSION of $VERSION"; fi
+RUN if [ "$VERSION" = "latest" ] ; then \
+        LATEST_VERSION=$( \
+            curl -v --silent  https://www.minecraft.net/en-us/download/server/bedrock/ 2>&1 | \
+            grep -o 'https://minecraft.azureedge.net/bin-linux/[^"]*' | \
+            sed 's#.*/bedrock-server-##' | sed 's/.zip//') && \
+        export VERSION=$LATEST_VERSION && \
+        echo "Setting VERSION to $LATEST_VERSION" ; \
+    else echo "Using VERSION of $VERSION"; \
+    fi
+    
 RUN apt-get update && \
     apt-get install -y unzip curl libcurl4 libssl1.0.0 && \
     curl https://minecraft.azureedge.net/bin-linux/bedrock-server-${VERSION}.zip --output bedrock-server.zip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-ARG BDS_Version=1.12.0.28
 FROM ubuntu:latest
+ARG BDS_Version=1.12.0.28
+
 ENV VERSION=$BDS_Version
 
 # Install dependencies, download and extract the bedrock server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BDS_Version=1.12.0.28
 FROM ubuntu:latest
-ENV VERSION=${BDS_Version}
+ENV VERSION=$BDS_Version
 
 # Install dependencies, download and extract the bedrock server
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ RUN if [ "$VERSION" = "latest" ] ; then \
         export VERSION=$LATEST_VERSION && \
         echo "Setting VERSION to $LATEST_VERSION" ; \
     else echo "Using VERSION of $VERSION"; \
-    fi
-RUN curl https://minecraft.azureedge.net/bin-linux/bedrock-server-${VERSION}.zip --output bedrock-server.zip && \
+    fi ; && \
+    curl https://minecraft.azureedge.net/bin-linux/bedrock-server-${VERSION}.zip --output bedrock-server.zip && \
     unzip bedrock-server.zip -d bedrock-server && \
     rm bedrock-server.zip
 


### PR DESCRIPTION
Hi!
  I added a RUN line which tests to see if the build argument BDS_VERSION equals 'latest' and, if so, fetches the download page to identify the latest version.
I left it so that the version is static for now (since my ability to test things is limited at the moment).
Thanks!